### PR TITLE
Fix #871 (-1 on variation tree for pass)

### DIFF
--- a/src/main/java/featurecat/lizzie/rules/Board.java
+++ b/src/main/java/featurecat/lizzie/rules/Board.java
@@ -410,6 +410,7 @@ public class Board implements LeelazListener {
       Stone[] stones = history.getStones().clone();
       Zobrist zobrist = history.getZobrist();
       int moveNumber = history.getMoveNumber() + 1;
+      int moveMNNumber = nextMoveMNNumber(newBranch);
       int[] moveNumberList =
           newBranch && history.getNext(true).isPresent()
               ? new int[Board.boardWidth * Board.boardHeight]
@@ -430,6 +431,7 @@ public class Board implements LeelazListener {
               0.0,
               0,
               0.0);
+      newState.moveMNNumber = moveMNNumber;
       newState.dummy = dummy;
 
       // update leelaz with pass
@@ -447,6 +449,12 @@ public class Board implements LeelazListener {
   /** overloaded method for pass(), chooses color in an alternating pattern */
   public void pass() {
     pass(history.isBlacksTurn() ? Stone.BLACK : Stone.WHITE);
+  }
+
+  private int nextMoveMNNumber(boolean newBranch) {
+    boolean isNewSubBranch = newBranch && (history.getCurrentHistoryNode().numberOfChildren() > 0);
+    boolean isMissingMoveMNNumber = history.getMoveMNNumber() < 0;
+    return isNewSubBranch ? 1 : isMissingMoveMNNumber ? -1 : history.getMoveMNNumber() + 1;
   }
 
   /**
@@ -517,12 +525,8 @@ public class Board implements LeelazListener {
       Stone[] stones = history.getStones().clone();
       Zobrist zobrist = history.getZobrist();
       Optional<int[]> lastMove = Optional.of(new int[] {x, y});
-      boolean isNewSubBranch =
-          newBranch && (history.getCurrentHistoryNode().numberOfChildren() > 0);
-      boolean isMissingMoveMNNumber = history.getMoveMNNumber() < 0;
       int moveNumber = history.getMoveNumber() + 1;
-      int moveMNNumber =
-          isNewSubBranch ? 1 : isMissingMoveMNNumber ? -1 : history.getMoveMNNumber() + 1;
+      int moveMNNumber = nextMoveMNNumber(newBranch);
       int[] moveNumberList =
           newBranch && history.getNext(true).isPresent()
               ? new int[Board.boardWidth * Board.boardHeight]


### PR DESCRIPTION
@xiaoyifang, we need yet another patch to fix featurecat#871.

Note that this is not our bug. :) You can confirm that Lizzie 0.7.4 shows a wrong move number "4" for the last move in the second branch in this SGF. It should be "3" correctly as long as `new-move-number-in-branch` is `true` in config.txt as usual.

~~~
(;B[aa](;W[ba])(;W[ab];B[tt];W[ac]))
~~~
