### PR TITLE
Fix overlap of movenums in variation tree

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/VariationTree.java
+++ b/src/main/java/featurecat/lizzie/gui/VariationTree.java
@@ -5,6 +5,7 @@ import featurecat.lizzie.rules.BoardHistoryNode;
 import featurecat.lizzie.util.Utils;
 import java.awt.BasicStroke;
 import java.awt.Color;
+import java.awt.Font;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Point;
@@ -118,8 +119,13 @@ public class VariationTree {
 
     // Draw all the nodes and lines in this lane (not variations)
     Color curcolor = null;
+    Font origFont = null, movenumFont = null;
     if (!calc) {
       curcolor = g.getColor();
+      origFont = g.getFont();
+      movenumFont =
+          new Font(
+              Lizzie.config.uiFontName, Font.PLAIN, Lizzie.config.showLargeSubBoard() ? 10 : 12);
       if (curposx > minposx && posy > 0) {
         if (startNode.previous().isPresent()) {
           if (Lizzie.config.showCommentNodeColor && !cur.getData().comment.isEmpty()) {
@@ -146,6 +152,7 @@ public class VariationTree {
           g.drawRect(curposx, posy, DOT_DIAM, DOT_DIAM);
         }
         g.setColor(Color.WHITE);
+        g.setFont(movenumFont);
         int moveMNNumber = startNode.getData().moveMNNumber;
         g.drawString(
             String.valueOf(moveMNNumber < 0 ? 0 : moveMNNumber),
@@ -153,6 +160,7 @@ public class VariationTree {
             posy + RING_DIAM);
       }
       g.setColor(curcolor);
+      g.setFont(origFont);
     }
 
     // Draw main line
@@ -204,8 +212,10 @@ public class VariationTree {
                 + (diff > 0 ? dotoffset + 1 : dotoffsety)
                 + (Lizzie.config.nodeColorMode == 0 ? 1 : 0));
         g.setColor(Color.WHITE);
+        g.setFont(movenumFont);
         g.drawString(
             String.valueOf(cur.getData().moveMNNumber), curposx + RING_DIAM, posy + RING_DIAM);
+        g.setFont(origFont);
       }
     }
     // Now we have drawn all the nodes in this variation, and has reached the bottom of this
@@ -244,8 +254,8 @@ public class VariationTree {
     }
 
     // Use dense tree for saving space if large-subboard
-    YSPACING = (Lizzie.config.showLargeSubBoard() ? 30 : 40);
-    XSPACING = YSPACING;
+    XSPACING = 40;
+    YSPACING = (int) (XSPACING * (Lizzie.config.showLargeSubBoard() ? 0.75 : 1));
 
     int strokeRadius = Lizzie.config.showBorder ? 2 : 0;
     if (!calc) {


### PR DESCRIPTION
@xiaoyifang, this PR fixes these issues in Normal UI (not Panel UI).

1. Movenums are overlapped in the variation tree on a large window.
2. Too large fonts are used for movenums in the variation tree if you turn off View > Panel > WinrateGraph.

![overlap](https://user-images.githubusercontent.com/38910552/110627199-01a4bf00-81e5-11eb-823e-62b0180a0c70.png)

~~~
(;SZ[19];B[pd];W[pp];B[qq];W[pq];B[qp];W[po];B[rn];W[dp];B[dd];W[qc];B[qd];W[pc];B[nc]
;W[nb];B[mb];W[oc];B[nd];W[od];B[oe];W[pe];B[re];W[pf];B[of];W[og];B[ng];W[qg];B[rc]
;W[ob];B[lc];W[rb];B[sb];W[qb];B[rg];W[rh];B[rf];W[nh];B[oh];W[pg];B[mg];W[qi];B[pa]
;W[ra];B[na];W[oa];B[ma];W[sg];B[sf];W[sd];B[sc];W[rd];B[se];W[rd];B[qe];W[sh];B[sd]
;W[qf];B[qa];W[oi];B[mh];W[ni];B[cq];W[cp];B[dq];W[fq];B[eq];W[ep];B[fr];W[bq];B[gq]
;W[fp];B[hr];W[cr];B[dr];W[ds];B[er];W[qr];B[rr];W[ro];B[qo];W[qn];B[rp];W[rm];B[mi]
;W[fc];B[ec];W[fd];B[df];W[jc];B[hc];W[sn];B[pr];W[hd];B[ic];W[id];B[jb];W[jd];B[kb]
;W[ke];B[le];W[lf](;B[kf])(;B[kg]))
~~~
